### PR TITLE
Daily Test Coverage Improver: Add unit tests for pkg/deprecation

### DIFF
--- a/pkg/deprecation/deprecation_test.go
+++ b/pkg/deprecation/deprecation_test.go
@@ -1,0 +1,195 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package deprecation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWarningConstants(t *testing.T) {
+	testCases := []struct {
+		warning  Warning
+		expected string
+	}{
+		{CRIRegistryMirrors, Prefix + "cri-registry-mirrors"},
+		{CRIRegistryAuths, Prefix + "cri-registry-auths"},
+		{CRIRegistryConfigs, Prefix + "cri-registry-configs"},
+		{CRICNIBinDir, Prefix + "cri-cni-bin-dir"},
+		{TracingOTLPConfig, Prefix + "tracing-processor-config"},
+		{TracingServiceConfig, Prefix + "tracing-service-config"},
+		{NRIV010Plugin, Prefix + "nri-v010-plugin"},
+	}
+
+	for _, tc := range testCases {
+		if string(tc.warning) != tc.expected {
+			t.Errorf("Expected %s, got %s", tc.expected, string(tc.warning))
+		}
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	expected := "io.containerd.deprecation/"
+	if Prefix != expected {
+		t.Errorf("Expected prefix %s, got %s", expected, Prefix)
+	}
+}
+
+func TestEnvPrefix(t *testing.T) {
+	expected := "CONTAINERD_ENABLE_DEPRECATED_"
+	if EnvPrefix != expected {
+		t.Errorf("Expected env prefix %s, got %s", expected, EnvPrefix)
+	}
+}
+
+func TestValid(t *testing.T) {
+	testCases := []struct {
+		warning Warning
+		valid   bool
+	}{
+		{CRIRegistryMirrors, true},
+		{CRIRegistryAuths, true},
+		{CRIRegistryConfigs, true},
+		{CRICNIBinDir, true},
+		{TracingOTLPConfig, true},
+		{TracingServiceConfig, true},
+		{NRIV010Plugin, true},
+		{Warning("nonexistent"), false},
+		{Warning(""), false},
+		{Warning("io.containerd.deprecation/fake"), false},
+	}
+
+	for _, tc := range testCases {
+		result := Valid(tc.warning)
+		if result != tc.valid {
+			t.Errorf("Valid(%s): expected %v, got %v", tc.warning, tc.valid, result)
+		}
+	}
+}
+
+func TestMessage(t *testing.T) {
+	testCases := []struct {
+		warning Warning
+		exists  bool
+	}{
+		{CRIRegistryMirrors, true},
+		{CRIRegistryAuths, true},
+		{CRIRegistryConfigs, true},
+		{CRICNIBinDir, true},
+		{TracingOTLPConfig, true},
+		{TracingServiceConfig, true},
+		{NRIV010Plugin, true},
+		{Warning("nonexistent"), false},
+	}
+
+	for _, tc := range testCases {
+		msg, ok := Message(tc.warning)
+		if ok != tc.exists {
+			t.Errorf("Message(%s) exists: expected %v, got %v", tc.warning, tc.exists, ok)
+		}
+		if tc.exists && msg == "" {
+			t.Errorf("Message(%s) returned empty string when should exist", tc.warning)
+		}
+		if !tc.exists && msg != "" {
+			t.Errorf("Message(%s) returned non-empty string when should not exist: %s", tc.warning, msg)
+		}
+	}
+}
+
+func TestMessageContent(t *testing.T) {
+	// Test that messages contain expected keywords to verify they're meaningful
+	testCases := []struct {
+		warning  Warning
+		keywords []string
+	}{
+		{CRIRegistryMirrors, []string{"mirrors", "deprecated", "containerd", "config_path"}},
+		{CRIRegistryAuths, []string{"auths", "deprecated", "containerd", "ImagePullSecrets"}},
+		{CRIRegistryConfigs, []string{"configs", "deprecated", "containerd", "config_path"}},
+		{CRICNIBinDir, []string{"bin_dir", "deprecated", "containerd", "bin_dirs"}},
+		{TracingOTLPConfig, []string{"otlp", "deprecated", "containerd", "OTLP", "environment"}},
+		{TracingServiceConfig, []string{"tracing", "deprecated", "containerd", "OTEL", "environment"}},
+		{NRIV010Plugin, []string{"NRI", "deprecated", "containerd", "v010-adapter"}},
+	}
+
+	for _, tc := range testCases {
+		msg, ok := Message(tc.warning)
+		if !ok {
+			t.Errorf("Message(%s) should exist but doesn't", tc.warning)
+			continue
+		}
+
+		for _, keyword := range tc.keywords {
+			if !strings.Contains(msg, keyword) {
+				t.Errorf("Message(%s) should contain keyword '%s', but message is: %s", tc.warning, keyword, msg)
+			}
+		}
+	}
+}
+
+func TestAllDefinedWarningsHaveMessages(t *testing.T) {
+	// Ensure every defined warning constant has a corresponding message
+	definedWarnings := []Warning{
+		CRIRegistryMirrors,
+		CRIRegistryAuths,
+		CRIRegistryConfigs,
+		CRICNIBinDir,
+		TracingOTLPConfig,
+		TracingServiceConfig,
+		NRIV010Plugin,
+	}
+
+	for _, warning := range definedWarnings {
+		if !Valid(warning) {
+			t.Errorf("Warning %s is defined but has no message", warning)
+		}
+		
+		msg, ok := Message(warning)
+		if !ok || msg == "" {
+			t.Errorf("Warning %s should have a non-empty message", warning)
+		}
+	}
+}
+
+func TestMessagesMapIntegrity(t *testing.T) {
+	// Verify the messages map has expected number of entries
+	expectedCount := 7 // Update if more warnings are added
+	actualCount := len(messages)
+	
+	if actualCount != expectedCount {
+		t.Errorf("Expected %d messages, got %d", expectedCount, actualCount)
+	}
+	
+	// Verify all messages in the map are non-empty
+	for warning, msg := range messages {
+		if msg == "" {
+			t.Errorf("Message for warning %s is empty", warning)
+		}
+		if !strings.Contains(string(warning), Prefix) {
+			t.Errorf("Warning %s doesn't contain expected prefix %s", warning, Prefix)
+		}
+	}
+}
+
+func TestWarningStringConversion(t *testing.T) {
+	warning := CRIRegistryMirrors
+	str := string(warning)
+	expected := "io.containerd.deprecation/cri-registry-mirrors"
+	
+	if str != expected {
+		t.Errorf("String conversion failed: expected %s, got %s", expected, str)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the `pkg/deprecation` package, improving test coverage from **0% to 100%**.

## Changes Made

- Added `pkg/deprecation/deprecation_test.go` with comprehensive test coverage
- Tests cover all exported functions: `Valid()` and `Message()`
- Tests verify all defined warning constants and their expected values
- Validates message content contains expected keywords
- Ensures integrity of the internal messages map

## Coverage Improvement

**Before:** 0% statement coverage
**After:** 100% statement coverage

The deprecation package was identified as having zero test coverage and was an excellent candidate for improvement due to its importance in warning users about deprecated features.

## Test Details

The test suite includes:

### Constant Validation
- Verifies all warning constants have correct prefix and naming
- Tests `Prefix` and `EnvPrefix` constant values

### Function Testing  
- `Valid()` function with both valid and invalid warning IDs
- `Message()` function for message retrieval and existence checks
- Edge cases with empty strings and nonexistent warnings

### Content Verification
- Ensures all deprecation messages contain relevant keywords
- Validates messages are meaningful and informative
- Checks that all defined warnings have corresponding messages

### Integrity Checks
- Verifies messages map completeness
- Ensures all warnings follow expected naming patterns
- Validates no empty or missing messages

## Commands Run

```bash
# Test execution
go test -v github.com/containerd/containerd/v2/pkg/deprecation

# Coverage verification  
go test -cover github.com/containerd/containerd/v2/pkg/deprecation
# Result: coverage: 100.0% of statements
```

## Areas for Future Improvement

Based on coverage analysis, other packages with 0% coverage that could benefit from similar treatment:
- `pkg/apparmor`
- `pkg/blockio`
- `pkg/dialer`
- `pkg/display`
- And many others in the cmd/ directory

---

> AI-generated content by [Daily Test Coverage Improver](https://github.com/Mossaka/containerd-fork/actions/runs/17330938447) may contain mistakes.