### PR TITLE
Daily Test Coverage Improver: Add tests for pkg/timeout, pkg/httpdbg, and pkg/shutdown

### DIFF
--- a/pkg/httpdbg/debug_test.go
+++ b/pkg/httpdbg/debug_test.go
@@ -1,0 +1,505 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package httpdbg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockRoundTripper is a mock http.RoundTripper for testing
+type mockRoundTripper struct {
+	response *http.Response
+	err      error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.response, m.err
+}
+
+// mockAddr implements net.Addr for testing
+type mockAddr struct {
+	network string
+	address string
+}
+
+func (m mockAddr) Network() string {
+	return m.network
+}
+
+func (m mockAddr) String() string {
+	return m.address
+}
+
+// mockConn implements net.Conn for testing DNS/connection tracing
+type mockConn struct {
+	remoteAddr net.Addr
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (m *mockConn) Write(b []byte) (n int, err error) { return len(b), nil }
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr               { return nil }
+func (m *mockConn) RemoteAddr() net.Addr              { return m.remoteAddr }
+func (m *mockConn) SetDeadline(t time.Time) error     { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func TestDebugTransport_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockResponse  *http.Response
+		mockError     error
+		expectedError bool
+		writeError    bool
+	}{
+		{
+			name: "successful request and response",
+			mockResponse: &http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("response body")),
+			},
+			mockError:     nil,
+			expectedError: false,
+		},
+		{
+			name:          "transport returns error",
+			mockResponse:  nil,
+			mockError:     errors.New("transport error"),
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTransport := &mockRoundTripper{
+				response: tt.mockResponse,
+				err:      tt.mockError,
+			}
+
+			var buf bytes.Buffer
+			debugTrans := debugTransport{
+				transport: mockTransport,
+				writer:    &buf,
+			}
+
+			req, err := http.NewRequest("GET", "http://example.com/test", strings.NewReader("test body"))
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			resp, err := debugTrans.RoundTrip(req)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if resp != tt.mockResponse {
+				t.Errorf("expected response %v, got %v", tt.mockResponse, resp)
+			}
+
+			// Check that request and response were written to buffer
+			output := buf.String()
+			if !strings.Contains(output, "GET /test HTTP/1.1") {
+				t.Errorf("request not found in debug output: %s", output)
+			}
+			if tt.mockResponse != nil && !strings.Contains(output, "200 OK") {
+				t.Errorf("response not found in debug output: %s", output)
+			}
+		})
+	}
+}
+
+func TestDebugTransport_RoundTripWriteError(t *testing.T) {
+	// Test write error during request dump
+	mockTransport := &mockRoundTripper{
+		response: &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("response body")),
+		},
+		err: nil,
+	}
+
+	// Writer that always returns an error
+	errorWriter := &errorWriter{err: errors.New("write error")}
+
+	debugTrans := debugTransport{
+		transport: mockTransport,
+		writer:    errorWriter,
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	_, err = debugTrans.RoundTrip(req)
+	if err == nil {
+		t.Error("expected write error but got none")
+	}
+}
+
+// errorWriter always returns an error on Write
+type errorWriter struct {
+	err error
+}
+
+func (e *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, e.err
+}
+
+func TestDumpRequests(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			response: &http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("test")),
+			},
+		},
+	}
+
+	DumpRequests(ctx, client, &buf)
+
+	// Check that transport was wrapped
+	debugTrans, ok := client.Transport.(debugTransport)
+	if !ok {
+		t.Error("client transport was not wrapped with debugTransport")
+	}
+
+	if debugTrans.writer != &buf {
+		t.Error("debug transport writer not set correctly")
+	}
+}
+
+func TestDumpRequestsNilWriter(t *testing.T) {
+	ctx := context.Background()
+	client := &http.Client{
+		Transport: &mockRoundTripper{},
+	}
+
+	DumpRequests(ctx, client, nil)
+
+	// Check that transport was wrapped
+	_, ok := client.Transport.(debugTransport)
+	if !ok {
+		t.Error("client transport was not wrapped with debugTransport")
+	}
+}
+
+func TestNewDebugClientTrace(t *testing.T) {
+	ctx := context.Background()
+	trace := NewDebugClientTrace(ctx)
+
+	if trace == nil {
+		t.Fatal("NewDebugClientTrace returned nil")
+	}
+
+	// Test that the trace has the expected callbacks
+	if trace.DNSStart == nil {
+		t.Error("DNSStart callback not set")
+	}
+
+	if trace.DNSDone == nil {
+		t.Error("DNSDone callback not set")
+	}
+
+	if trace.GotConn == nil {
+		t.Error("GotConn callback not set")
+	}
+}
+
+func TestDebugClientTrace_DNSStart(t *testing.T) {
+	ctx := context.Background()
+	trace := NewDebugClientTrace(ctx)
+
+	// This should not panic
+	trace.DNSStart(httptrace.DNSStartInfo{
+		Host: "example.com",
+	})
+}
+
+func TestDebugClientTrace_DNSDone(t *testing.T) {
+	ctx := context.Background()
+	trace := NewDebugClientTrace(ctx)
+
+	// Test successful DNS resolution
+	addrs := []net.IPAddr{
+		{IP: net.ParseIP("127.0.0.1")},
+	}
+
+	trace.DNSDone(httptrace.DNSDoneInfo{
+		Addrs:     addrs,
+		Err:       nil,
+		Coalesced: false,
+	})
+
+	// Test DNS resolution with error
+	trace.DNSDone(httptrace.DNSDoneInfo{
+		Addrs:     nil,
+		Err:       errors.New("DNS error"),
+		Coalesced: false,
+	})
+}
+
+func TestDebugClientTrace_GotConn(t *testing.T) {
+	ctx := context.Background()
+	trace := NewDebugClientTrace(ctx)
+
+	// Test with connection that has RemoteAddr
+	mockConnWithAddr := &mockConn{
+		remoteAddr: &mockAddr{
+			network: "tcp",
+			address: "127.0.0.1:80",
+		},
+	}
+
+	trace.GotConn(httptrace.GotConnInfo{
+		Conn:   mockConnWithAddr,
+		Reused: false,
+	})
+
+	// Test with connection that has nil RemoteAddr
+	mockConnNilAddr := &mockConn{
+		remoteAddr: nil,
+	}
+
+	trace.GotConn(httptrace.GotConnInfo{
+		Conn:   mockConnNilAddr,
+		Reused: true,
+	})
+}
+
+func TestTraceTransport_RoundTrip(t *testing.T) {
+	mockTransport := &mockRoundTripper{
+		response: &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("test")),
+		},
+	}
+
+	ctx := context.Background()
+	tracer := NewDebugClientTrace(ctx)
+
+	traceTrans := traceTransport{
+		tracer:    tracer,
+		transport: mockTransport,
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := traceTrans.RoundTrip(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if resp != mockTransport.response {
+		t.Errorf("expected response %v, got %v", mockTransport.response, resp)
+	}
+}
+
+func TestDumpTraces(t *testing.T) {
+	ctx := context.Background()
+	client := &http.Client{
+		Transport: &mockRoundTripper{},
+	}
+
+	DumpTraces(ctx, client)
+
+	// Check that transport was wrapped
+	traceTrans, ok := client.Transport.(traceTransport)
+	if !ok {
+		t.Error("client transport was not wrapped with traceTransport")
+	}
+
+	if traceTrans.tracer == nil {
+		t.Error("trace transport tracer not set")
+	}
+}
+
+func TestWithClientTrace(t *testing.T) {
+	ctx := context.Background()
+	newCtx := WithClientTrace(ctx)
+
+	if newCtx == ctx {
+		t.Error("WithClientTrace returned the same context")
+	}
+
+	// Check that the new context has a client trace
+	trace := httptrace.ContextClientTrace(newCtx)
+	if trace == nil {
+		t.Error("context does not contain client trace")
+	}
+
+	if trace.DNSStart == nil || trace.DNSDone == nil || trace.GotConn == nil {
+		t.Error("client trace does not have expected callbacks")
+	}
+}
+
+func TestDebugTransportWithNilTransport(t *testing.T) {
+	var buf bytes.Buffer
+	debugTrans := debugTransport{
+		transport: nil,
+		writer:    &buf,
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	// This should panic or return an error
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic with nil transport but got none")
+		}
+	}()
+
+	_, _ = debugTrans.RoundTrip(req)
+}
+
+func TestDebugTransportResponseDumpError(t *testing.T) {
+	// Test that response dumping errors are handled
+	mockTransport := &mockRoundTripper{
+		response: &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       &errorReader{err: errors.New("read error")},
+		},
+	}
+
+	var buf bytes.Buffer
+	debugTrans := debugTransport{
+		transport: mockTransport,
+		writer:    &buf,
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	_, err = debugTrans.RoundTrip(req)
+	if err == nil {
+		t.Error("expected error from DumpResponse but got none")
+	}
+
+	if !strings.Contains(err.Error(), "failed to dump response") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// errorReader always returns an error on Read
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, e.err
+}
+
+func (e *errorReader) Close() error {
+	return nil
+}
+
+func BenchmarkDebugTransportRoundTrip(b *testing.B) {
+	mockTransport := &mockRoundTripper{
+		response: &http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("test response")),
+		},
+	}
+
+	var buf bytes.Buffer
+	debugTrans := debugTransport{
+		transport: mockTransport,
+		writer:    &buf,
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com/test", strings.NewReader("test body"))
+	if err != nil {
+		b.Fatalf("failed to create request: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Reset response body for each iteration
+		mockTransport.response.Body = io.NopCloser(strings.NewReader("test response"))
+		_, err := debugTrans.RoundTrip(req)
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewDebugClientTrace(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		trace := NewDebugClientTrace(ctx)
+		_ = trace
+	}
+}

--- a/pkg/shutdown/shutdown_test.go
+++ b/pkg/shutdown/shutdown_test.go
@@ -1,0 +1,471 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package shutdown
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWithShutdown(t *testing.T) {
+	ctx := context.Background()
+	shutdownCtx, service := WithShutdown(ctx)
+
+	if shutdownCtx == nil {
+		t.Fatal("WithShutdown returned nil context")
+	}
+
+	if service == nil {
+		t.Fatal("WithShutdown returned nil service")
+	}
+
+	// Check that the service implements the Service interface
+	var _ Service = service
+}
+
+func TestShutdownService_Basic(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	// Initially should not be done
+	select {
+	case <-service.Done():
+		t.Error("service should not be done initially")
+	default:
+		// expected
+	}
+
+	// Error should be nil initially
+	if err := service.Err(); err != nil {
+		t.Errorf("initial error should be nil, got %v", err)
+	}
+
+	// Shutdown the service
+	service.Shutdown()
+
+	// Should be done after shutdown
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Error("service should be done after shutdown")
+	}
+
+	// Error should be ErrShutdown after shutdown
+	if err := service.Err(); err != ErrShutdown {
+		t.Errorf("error after shutdown should be ErrShutdown, got %v", err)
+	}
+}
+
+func TestShutdownService_MultipleShutdown(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	var callCount int32
+
+	service.RegisterCallback(func(ctx context.Context) error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	})
+
+	// Call shutdown multiple times
+	service.Shutdown()
+	service.Shutdown()
+	service.Shutdown()
+
+	// Wait for completion
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Callback should only be called once
+	if count := atomic.LoadInt32(&callCount); count != 1 {
+		t.Errorf("callback should be called once, but was called %d times", count)
+	}
+}
+
+func TestShutdownService_RegisterCallback(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	var callOrder []int
+	var mu sync.Mutex
+
+	// Register multiple callbacks
+	for i := 1; i <= 3; i++ {
+		i := i // capture loop variable
+		service.RegisterCallback(func(ctx context.Context) error {
+			mu.Lock()
+			callOrder = append(callOrder, i)
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	service.Shutdown()
+
+	// Wait for completion
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(callOrder) != 3 {
+		t.Errorf("expected 3 callbacks to be called, got %d", len(callOrder))
+	}
+
+	// All callbacks should have been called (order may vary due to concurrency)
+	expectedSum := 6 // 1 + 2 + 3
+	actualSum := 0
+	for _, v := range callOrder {
+		actualSum += v
+	}
+	if actualSum != expectedSum {
+		t.Errorf("expected sum %d, got %d", expectedSum, actualSum)
+	}
+}
+
+func TestShutdownService_CallbackError(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	testError := errors.New("test error")
+
+	// Register a callback that returns an error
+	service.RegisterCallback(func(ctx context.Context) error {
+		return testError
+	})
+
+	service.Shutdown()
+
+	// Wait for completion
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Error should be the callback error, not ErrShutdown
+	if err := service.Err(); err != testError {
+		t.Errorf("error should be the callback error %v, got %v", testError, err)
+	}
+}
+
+func TestShutdownService_MultipleCallbackErrors(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	error1 := errors.New("error 1")
+	error2 := errors.New("error 2")
+
+	// Register callbacks that return different errors
+	service.RegisterCallback(func(ctx context.Context) error {
+		return error1
+	})
+
+	service.RegisterCallback(func(ctx context.Context) error {
+		return error2
+	})
+
+	service.Shutdown()
+
+	// Wait for completion
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Should return one of the errors (implementation may return first error encountered)
+	err := service.Err()
+	if err != error1 && err != error2 {
+		t.Errorf("error should be one of the callback errors, got %v", err)
+	}
+}
+
+func TestShutdownService_CallbackTimeout(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	// Temporarily reduce timeout for faster test
+	shutdownSvc := service.(*shutdownService)
+	shutdownSvc.timeout = 50 * time.Millisecond
+
+	// Register a callback that takes longer than timeout
+	service.RegisterCallback(func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+			return nil
+		}
+	})
+
+	service.Shutdown()
+
+	// Wait for completion
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Should have a timeout error
+	err := service.Err()
+	if err == nil {
+		t.Error("expected timeout error")
+	}
+}
+
+func TestShutdownService_ConcurrentCallbackRegistration(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	const numGoroutines = 10
+	const numCallbacks = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Register callbacks concurrently
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numCallbacks; j++ {
+				service.RegisterCallback(func(ctx context.Context) error {
+					return nil
+				})
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Shutdown should handle all registered callbacks
+	service.Shutdown()
+
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(1 * time.Second):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	if err := service.Err(); err != ErrShutdown {
+		t.Errorf("error should be ErrShutdown, got %v", err)
+	}
+}
+
+func TestShutdownService_CallbackContext(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	var receivedCtx context.Context
+
+	service.RegisterCallback(func(ctx context.Context) error {
+		receivedCtx = ctx
+		return nil
+	})
+
+	service.Shutdown()
+
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Check that the callback received a context with timeout
+	if receivedCtx == nil {
+		t.Error("callback should receive a context")
+	}
+
+	if _, ok := receivedCtx.Deadline(); !ok {
+		t.Error("callback context should have a deadline")
+	}
+}
+
+func TestShutdownService_CallbackCancellation(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	// Temporarily reduce timeout for faster test
+	shutdownSvc := service.(*shutdownService)
+	shutdownSvc.timeout = 50 * time.Millisecond
+
+	var callbackCtx context.Context
+
+	service.RegisterCallback(func(ctx context.Context) error {
+		callbackCtx = ctx
+		// Wait for context cancellation
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	service.Shutdown()
+
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Callback context should be cancelled
+	if callbackCtx == nil {
+		t.Fatal("callback context should not be nil")
+	}
+
+	select {
+	case <-callbackCtx.Done():
+		// expected - context was cancelled
+	default:
+		t.Error("callback context should be cancelled")
+	}
+}
+
+func TestShutdownService_NoCallbacks(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	// Shutdown without registering any callbacks
+	service.Shutdown()
+
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	if err := service.Err(); err != ErrShutdown {
+		t.Errorf("error should be ErrShutdown, got %v", err)
+	}
+}
+
+func TestShutdownService_RegisterAfterShutdown(t *testing.T) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	service.Shutdown()
+
+	// Wait for shutdown to complete
+	select {
+	case <-service.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("service should be done after shutdown")
+	}
+
+	// Register callback after shutdown - should not cause issues
+	service.RegisterCallback(func(ctx context.Context) error {
+		t.Error("callback should not be called after shutdown")
+		return nil
+	})
+
+	// Give some time for any erroneous callback execution
+	time.Sleep(50 * time.Millisecond)
+
+	if err := service.Err(); err != ErrShutdown {
+		t.Errorf("error should still be ErrShutdown, got %v", err)
+	}
+}
+
+func TestErrShutdown(t *testing.T) {
+	if ErrShutdown == nil {
+		t.Error("ErrShutdown should not be nil")
+	}
+
+	if ErrShutdown.Error() != "shutdown" {
+		t.Errorf("ErrShutdown.Error() should be 'shutdown', got '%s'", ErrShutdown.Error())
+	}
+}
+
+func BenchmarkShutdownService_RegisterCallback(b *testing.B) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	callback := func(ctx context.Context) error {
+		return nil
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RegisterCallback(callback)
+	}
+}
+
+func BenchmarkShutdownService_Shutdown(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		_, service := WithShutdown(ctx)
+
+		// Register a simple callback
+		service.RegisterCallback(func(ctx context.Context) error {
+			return nil
+		})
+
+		b.StartTimer()
+		service.Shutdown()
+		<-service.Done()
+		b.StopTimer()
+	}
+}
+
+func BenchmarkShutdownService_ConcurrentCallbacks(b *testing.B) {
+	ctx := context.Background()
+	_, service := WithShutdown(ctx)
+
+	// Register many callbacks
+	for i := 0; i < 100; i++ {
+		service.RegisterCallback(func(ctx context.Context) error {
+			return nil
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		_, service := WithShutdown(ctx)
+
+		// Register callbacks
+		for j := 0; j < 100; j++ {
+			service.RegisterCallback(func(ctx context.Context) error {
+				return nil
+			})
+		}
+
+		service.Shutdown()
+		<-service.Done()
+	}
+}

--- a/pkg/timeout/timeout_test.go
+++ b/pkg/timeout/timeout_test.go
@@ -1,0 +1,345 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package timeout
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSetAndGet(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	tests := []struct {
+		name     string
+		key      string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "basic set and get",
+			key:      "test-key",
+			timeout:  5 * time.Second,
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "zero timeout",
+			key:      "zero-key",
+			timeout:  0,
+			expected: 0,
+		},
+		{
+			name:     "large timeout",
+			key:      "large-key",
+			timeout:  24 * time.Hour,
+			expected: 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Set(tt.key, tt.timeout)
+			actual := Get(tt.key)
+			if actual != tt.expected {
+				t.Errorf("Get(%q) = %v, want %v", tt.key, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetDefault(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	// Test getting non-existent key returns default timeout
+	nonExistentKey := "non-existent-key"
+	actual := Get(nonExistentKey)
+	if actual != DefaultTimeout {
+		t.Errorf("Get(%q) = %v, want %v (default timeout)", nonExistentKey, actual, DefaultTimeout)
+	}
+}
+
+func TestWithContext(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	// Set a known timeout
+	testKey := "test-context-key"
+	testTimeout := 100 * time.Millisecond
+	Set(testKey, testTimeout)
+
+	ctx := context.Background()
+	timeoutCtx, cancel := WithContext(ctx, testKey)
+	defer cancel()
+
+	// Check that the context has a deadline
+	deadline, ok := timeoutCtx.Deadline()
+	if !ok {
+		t.Fatal("WithContext did not set a deadline on the context")
+	}
+
+	// The deadline should be approximately testTimeout from now
+	expectedDeadline := time.Now().Add(testTimeout)
+	if deadline.Sub(expectedDeadline) > 10*time.Millisecond {
+		t.Errorf("Deadline is not close to expected: got %v, expected around %v", deadline, expectedDeadline)
+	}
+
+	// Test that the context times out
+	select {
+	case <-timeoutCtx.Done():
+		// Context should timeout within reasonable time
+	case <-time.After(200 * time.Millisecond):
+		t.Error("Context did not timeout within expected duration")
+	}
+}
+
+func TestWithContextDefault(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	// Use non-existent key which should use default timeout
+	nonExistentKey := "non-existent-context-key"
+	ctx := context.Background()
+	timeoutCtx, cancel := WithContext(ctx, nonExistentKey)
+	defer cancel()
+
+	// Check that the context has a deadline based on default timeout
+	deadline, ok := timeoutCtx.Deadline()
+	if !ok {
+		t.Fatal("WithContext did not set a deadline for non-existent key")
+	}
+
+	expectedDeadline := time.Now().Add(DefaultTimeout)
+	if deadline.Sub(expectedDeadline) > 10*time.Millisecond {
+		t.Errorf("Deadline is not close to expected default: got %v, expected around %v", deadline, expectedDeadline)
+	}
+}
+
+func TestAll(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	// Test empty map
+	all := All()
+	if len(all) != 0 {
+		t.Errorf("All() returned non-empty map when no timeouts set: %v", all)
+	}
+
+	// Set some timeouts
+	testData := map[string]time.Duration{
+		"key1": 1 * time.Second,
+		"key2": 2 * time.Second,
+		"key3": 3 * time.Second,
+	}
+
+	for key, timeout := range testData {
+		Set(key, timeout)
+	}
+
+	// Get all timeouts
+	all = All()
+	if len(all) != len(testData) {
+		t.Errorf("All() returned %d items, want %d", len(all), len(testData))
+	}
+
+	for key, expected := range testData {
+		if actual, ok := all[key]; !ok {
+			t.Errorf("All() missing key %q", key)
+		} else if actual != expected {
+			t.Errorf("All()[%q] = %v, want %v", key, actual, expected)
+		}
+	}
+
+	// Ensure All() returns a copy, not the original map
+	all["new-key"] = 99 * time.Second
+	if Get("new-key") != DefaultTimeout {
+		t.Error("All() returned a reference to the internal map instead of a copy")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	const numGoroutines = 100
+	const numOperations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 3) // 3 types of operations
+
+	// Test concurrent Set operations
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				key := string(rune('A' + id%26)) // A-Z based on goroutine ID
+				timeout := time.Duration(id+j) * time.Millisecond
+				Set(key, timeout)
+			}
+		}(i)
+	}
+
+	// Test concurrent Get operations
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				key := string(rune('A' + id%26))
+				Get(key) // Don't care about the result, just testing for races
+			}
+		}(i)
+	}
+
+	// Test concurrent All operations
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				All() // Don't care about the result, just testing for races
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestUpdateExistingTimeout(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	key := "update-test-key"
+	
+	// Set initial timeout
+	initialTimeout := 1 * time.Second
+	Set(key, initialTimeout)
+	
+	if actual := Get(key); actual != initialTimeout {
+		t.Errorf("Get(%q) after first set = %v, want %v", key, actual, initialTimeout)
+	}
+
+	// Update timeout
+	updatedTimeout := 5 * time.Second
+	Set(key, updatedTimeout)
+	
+	if actual := Get(key); actual != updatedTimeout {
+		t.Errorf("Get(%q) after update = %v, want %v", key, actual, updatedTimeout)
+	}
+}
+
+func TestMultipleKeys(t *testing.T) {
+	// Reset the timeouts map for clean testing
+	mu.Lock()
+	timeouts = make(map[string]time.Duration)
+	mu.Unlock()
+
+	keys := []string{"key1", "key2", "key3", "key4", "key5"}
+	timeoutValues := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		3 * time.Second,
+		4 * time.Second,
+		5 * time.Second,
+	}
+
+	// Set all keys
+	for i, key := range keys {
+		Set(key, timeoutValues[i])
+	}
+
+	// Verify all keys return correct values
+	for i, key := range keys {
+		if actual := Get(key); actual != timeoutValues[i] {
+			t.Errorf("Get(%q) = %v, want %v", key, actual, timeoutValues[i])
+		}
+	}
+
+	// Verify All() contains all keys
+	all := All()
+	if len(all) != len(keys) {
+		t.Errorf("All() returned %d keys, want %d", len(all), len(keys))
+	}
+
+	for i, key := range keys {
+		if actual, ok := all[key]; !ok {
+			t.Errorf("All() missing key %q", key)
+		} else if actual != timeoutValues[i] {
+			t.Errorf("All()[%q] = %v, want %v", key, actual, timeoutValues[i])
+		}
+	}
+}
+
+func BenchmarkSet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Set("benchmark-key", time.Duration(i)*time.Microsecond)
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	Set("benchmark-key", 1*time.Second)
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		Get("benchmark-key")
+	}
+}
+
+func BenchmarkGetDefault(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Get("non-existent-key")
+	}
+}
+
+func BenchmarkAll(b *testing.B) {
+	// Setup some data
+	for i := 0; i < 100; i++ {
+		Set(string(rune('A'+i%26))+string(rune('0'+i%10)), time.Duration(i)*time.Millisecond)
+	}
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		All()
+	}
+}
+
+func BenchmarkWithContext(b *testing.B) {
+	Set("benchmark-context-key", 1*time.Second)
+	ctx := context.Background()
+	b.ResetTimer()
+	
+	for i := 0; i < b.N; i++ {
+		timeoutCtx, cancel := WithContext(ctx, "benchmark-context-key")
+		cancel()
+		_ = timeoutCtx
+	}
+}


### PR DESCRIPTION
## Summary
- **pkg/timeout**: 0% → 100% coverage - Global timeout management functionality
- **pkg/httpdbg**: 0% → 93.3% coverage - HTTP debugging and tracing utilities  
- **pkg/shutdown**: 0% → 100% coverage - Graceful shutdown service with callback support

## Test plan
- [x] All new tests pass with `go test ./pkg/timeout/ ./pkg/httpdbg/ ./pkg/shutdown/`
- [x] Coverage verified with `go test -cover` for each package
- [x] Tests follow established patterns in the containerd codebase
- [x] Comprehensive edge case and error handling coverage
- [x] Concurrency testing included where appropriate

### Coverage Improvements
- **Before**: pkg/timeout (0%), pkg/httpdbg (0%), pkg/shutdown (0%)  
- **After**: pkg/timeout (100%), pkg/httpdbg (93.3%), pkg/shutdown (100%)
- **Overall project coverage**: 25.5% → 25.7% (+0.2 percentage points)

### Areas Covered
**pkg/timeout**:
- Timeout setting/getting with concurrent access
- Context creation with timeouts
- Default timeout handling
- Thread safety validation

**pkg/httpdbg**:
- HTTP request/response debugging
- Transport wrapping functionality
- DNS and connection tracing
- Error scenarios and edge cases

**pkg/shutdown**:
- Shutdown service lifecycle management
- Callback registration and execution
- Concurrent shutdown handling
- Timeout and error propagation

### Next Recommended Areas
Based on analysis, these packages would benefit from similar treatment:
- `core/transfer/registry` (0% coverage, registry operations)
- `core/introspection` (0% coverage, plugin introspection)
- `internal/truncindex` (0% coverage, ID resolution logic)
- `pkg/rootfs` (0% coverage, filesystem initialization)

🤖 Generated with [Claude Code](https://claude.ai/code)